### PR TITLE
#13, use NetworkInterface replace NetworkInformation to identify network avaiable

### DIFF
--- a/Library/Unicorn.UWP/Utility/NetworkHelper.cs
+++ b/Library/Unicorn.UWP/Utility/NetworkHelper.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 using Windows.Networking.Connectivity;
 
@@ -80,17 +81,8 @@ namespace Unicorn
         /// <returns></returns>
         public static bool CheckInternetAvailable()
         {
-            // 在 Store 執行時，手動將網路卡停用時，在 GetNetworkConnectivityLevel() 會取得 LocalAccess
-            // 在 Phone 執行時，開啟飛航模式時，在 NetworkInformation.GetInternetConnectionProfile() 就會取得 null
-            // 在 Phone 上即便是連上一個無法對外的無線網路，在 GetNetworkConnectivityLevel() 仍然會取得 NetworkConnectivityLevel.InternetAccess
-            // 但此狀況不在正常使用範圍
-            // PS: 要測試 Phone 的狀態記得用實機，模擬器的狀態不準（即便你開啟飛航模式或用模擬器的網路模擬讓網路停止）
-            
-            var connectionProfile = NetworkInformation.GetInternetConnectionProfile();
-
-            // The profile for the connection currently used to connect the machine to the Internet, 
-            // or null if there is no connection profile with a suitable connection.
-            return connectionProfile != null;
+            bool available = NetworkInterface.GetIsNetworkAvailable();
+            return available;
         }
 
         /// <summary>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.net.networkinformation.networkinterface.getisnetworkavailable?view=dotnet-uwp-10.0#System_Net_NetworkInformation_NetworkInterface_GetIsNetworkAvailable

可以支援 .net core / .net framework / uwp / .net standard 。
